### PR TITLE
use cryptography as base name in routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ function Users() {
 class App extends Component {
   render() {
     return (
-			<Router>
+			<Router basename="/cryptography">
 	      <div>
 	        <nav>
 	          <ul>


### PR DESCRIPTION
## Problem
Current routing takes me to https://mdave16.github.io/users/, which is a real `404` :crying_cat_face: 
## Solution
append a basename, so the project itself knows to always go from `/cryptogrophy` as a base
## Additional Comments
This is actually in the documentation, I just didn't follow it well.